### PR TITLE
Use `dep:` syntax for `dot2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "For scheduling directed acyclic graphs of nodes that create, read
 
 [features]
 default = ["dot"]
-dot = ["dot2"]
+dot = ["dep:dot2"]
 
 [dependencies]
 dot2 = { version = "^1.0", optional = true }


### PR DESCRIPTION
This prevents creating an implicit feature `dot2` that isn't needed.

This would be visible when doing a `cargo add dagga`.